### PR TITLE
Update to habanero_board.xml to enable Live MRW for OpenPower

### DIFF
--- a/habanero_board.xml
+++ b/habanero_board.xml
@@ -29,7 +29,7 @@
 	<part-instance><id>UCENTAUR3</id><part-id>OPNPWR_CENTAUR</part-id><position>2</position><ecmd>yes</ecmd><ec-level>DD1</ec-level></part-instance>
 	<part-instance><id>UCENTAUR4</id><part-id>OPNPWR_CENTAUR</part-id><position>3</position><ecmd>yes</ecmd><ec-level>DD1</ec-level></part-instance>
 	<part-instance><id>U0</id><part-id>PEX8748_HABANERO</part-id><position>0</position></part-instance>
-	<part-instance><id>U1</id><part-id>VPD</part-id><position>0</position><content-type>PLANAR_VPD</content-type><seeprom-byte-address-offset></seeprom-byte-address-offset><seeprom-write-page-boundary></seeprom-write-page-boundary><vpd-size>24c256</vpd-size><seeprom-memory-size></seeprom-memory-size></part-instance>
+	<part-instance><id>U1</id><part-id>VPD</part-id><position>0</position><content-type>ALL_CENTAUR_VPD</content-type><seeprom-byte-address-offset></seeprom-byte-address-offset><seeprom-write-page-boundary></seeprom-write-page-boundary><vpd-size>24c256</vpd-size><seeprom-memory-size></seeprom-memory-size></part-instance>
 	<part-instance><id>U2</id><part-id>HABANERO_APSS</part-id><position>0</position><ec-level>1</ec-level></part-instance>
 </part-instances>
 <connector-instances>
@@ -562,7 +562,7 @@
 		<use-for-presence-detect>No</use-for-presence-detect>
 		<address>0xA0</address>
 		<speed>400</speed>
-		<source><connector-instance-id>JSCM</connector-instance-id><pin-name>I2C LIGHTPATH</pin-name></source>
+		<source><connector-instance-id>JSCM</connector-instance-id><pin-name>I2C_VPD</pin-name></source>
 		<endpoint><part-instance-id>U1</part-instance-id><unit-name>I2C</unit-name></endpoint>
 	</i2c>
 	<i2c>


### PR DESCRIPTION
habanero_board.xml is updated in part to acknowledge that the VPD on
the backplane is for the Centaurs on the system.

Matt Spinler made this change and I have tested it with hostboot build tools.
