### PR TITLE
Update xml with correct sensor number for CPU Func sensor

### DIFF
--- a/habanero.pmc.xml
+++ b/habanero.pmc.xml
@@ -924,7 +924,7 @@
 	<name>Checkstop</name>
 	<dev_name>digital_oem</dev_name>
 	<sensor_id>12</sensor_id>
-	<entity_id>0x3</entity_id>
+	<entity_id>0xd9</entity_id>
 	<sensor_type>0x7</sensor_type>
 	<entity_instance>0x0</entity_instance>
 </device>

--- a/habanero.xml
+++ b/habanero.xml
@@ -3008,7 +3008,7 @@
 	<id>/sys-0/node-0/motherboard-0/proc_socket-0/module-0/proc/cpu_func_sensor</id>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0x0C</value>
+	<value>0x4E</value>
 	</property>
 </globalSetting>
 <globalSetting>


### PR DESCRIPTION
    -Update CPU Func sensor with the correct sensor number.
    -Modify the checkstop sensor entity id to avoid collision with
     CPU Func sensor when processing