### PR TITLE
Move MSS_INTERLEAVE_ENABLE to processor target

### DIFF
--- a/habanero.xml
+++ b/habanero.xml
@@ -4851,10 +4851,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>MSS_INTERLEAVE_ENABLE</id>
-		<default>0xE</default>
-	</attribute>
-	<attribute>
 		<id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
 		<default>24</default>
 	</attribute>
@@ -7074,6 +7070,10 @@
 	<attribute>
 		<id>RNG_BASE_ADDR</id>
 		<default>1,0x0003FFFF40000000,0x4000,0x1000,0</default>
+    </attribute>
+    <attribute>
+		<id>MSS_INTERLEAVE_ENABLE</id>
+		<default>0xE</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>


### PR DESCRIPTION
Update habanero.xml so that MSS_INTERLEAVE_ENABLE is associated with the processor target.