### PR TITLE
Add support for Habanero to support multiple nest frequencies

### DIFF
--- a/habanero.xml
+++ b/habanero.xml
@@ -5046,6 +5046,10 @@
 		<id>X_EREPAIR_THRESHOLD_MNFG</id>
 		<default>0</default>
 	</attribute>
+        <attribute>
+                <id>MRW_NEST_CAPABLE_FREQUENCIES_SYS</id>
+                <default>2000_MHZ_OR_2400_MHZ</default>
+        </attribute>
 </targetInstance>
 <targetInstance>
 	<id>node-0</id>


### PR DESCRIPTION
The MRW_NEST_CAPABLE_FREQUENCIES_SYS was updated to support both
2000MHz and 2400MHz nest frequencies as part of the effort to support
32x32GB DIMMs.

This change was requested by Dan Crowell and Benjamin Mashak.

This change should not break anything currently and will be used by upcoming hostboot commits.
