### PR TITLE
Apply patch we've been carrying in op-build

### DIFF
--- a/habanero.xml
+++ b/habanero.xml
@@ -4871,6 +4871,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+	        <id>BMC_FRU_ID</id>
+	        <default>43</default>
+        </attribute>
+	<attribute>
 		<id>FRU_NAME</id>
 		<default></default>
 	</attribute>


### PR DESCRIPTION
```
$ git log openpower/package/habanero-xml/habanero-xml-0002-Add-System-Fw-Fru-Id.patch
commit ffe83706f87d9d9e9e860fc5f0032d0aa113e76d
Author: Bill Hoffa <wghoffa@us.ibm.com>
Date:   Mon Mar 30 21:37:20 2015 -0500

    Habanero Updates for SL
```

So, nobody has used a system without this patch in over 2 years. We should just have the patch in the upstream repo.