### PR TITLE
Fix IBSCOM_MCS_BASE_ADDR value

### DIFF
--- a/habanero.xml
+++ b/habanero.xml
@@ -8694,8 +8694,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -8746,8 +8745,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -8798,8 +8796,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -8850,8 +8847,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -9977,8 +9973,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -10029,8 +10024,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -10081,8 +10075,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -10133,8 +10126,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>


### PR DESCRIPTION
The whitespace was tripping up the xmltohb.pl script.

Signed-off-by: Joel Stanley <joel@jms.id.au>